### PR TITLE
chore(build): gradle updates and cleanup build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,9 +14,6 @@
  * limitations under the License.
  */
 
-import org.gradle.util.DistributionLocator
-import org.gradle.util.GradleVersion
-
 plugins {
     // https://docs.gradle.org/current/userguide/java_library_plugin.html
     id 'java-library'
@@ -53,12 +50,8 @@ targetCompatibility = JavaVersion.VERSION_11
 wrapper {
     distributionType = 'ALL'
     doLast {
-        final DistributionLocator locator = new DistributionLocator()
-        final GradleVersion version = GradleVersion.version(wrapper.gradleVersion)
-        final URI distributionUri = locator.getDistributionFor(version, wrapper.distributionType.name().toLowerCase(Locale.ENGLISH))
-        final URI sha256Uri = new URI(distributionUri.toString() + ".sha256")
-        final String sha256Sum = new String(sha256Uri.toURL().bytes)
-        wrapper.getPropertiesFile() << "distributionSha256Sum=${sha256Sum}\n"
+        def sha256Sum = new String(new URL("${distributionUrl}.sha256").bytes)
+        propertiesFile << "distributionSha256Sum=${sha256Sum}\n"
         println "Added checksum to wrapper properties"
     }
 }
@@ -73,7 +66,7 @@ ext {
     jacksonVersion = "2.15.2" // This Jackson is used in the tests.
     jupiterVersion = "5.9.3"
     kafkaVersion = '2.6.3'
-    jettyVersion = "9.4.39.v20210325"
+    jettyVersion = "9.4.51.v20230217"
     junit4Version = "4.13.2"
     jsr305Version = "3.0.2"
     log4jVersion = "2.20.0"
@@ -106,8 +99,8 @@ sourceSets {
 
 idea {
     module {
-        testSourceDirs += project.sourceSets.integrationTest.java.srcDirs
-        testSourceDirs += project.sourceSets.integrationTest.resources.srcDirs
+        testSources.from(sourceSets.integrationTest.java.srcDirs)
+        testSources.from(sourceSets.integrationTest.resources.srcDirs)
     }
 }
 
@@ -165,7 +158,7 @@ dependencies {
 }
 
 checkstyle {
-    toolVersion '8.25'
+    toolVersion '10.12.0'
 }
 
 compileJava {
@@ -179,13 +172,22 @@ compileJava {
     }
 }
 
-task integrationTest(type: Test) {
+test {
+    useJUnitPlatform {
+        includeEngines 'junit-jupiter'
+    }
+}
+
+tasks.register('integrationTest', Test) {
     description = 'Runs the integration tests.'
     group = 'verification'
     testClassesDirs = sourceSets.integrationTest.output.classesDirs
     classpath = sourceSets.integrationTest.runtimeClasspath
 
-    dependsOn test, distTar
+    // defines testing order
+    shouldRunAfter test
+    // requires archive for connect runner
+    dependsOn distTar
 
     useJUnitPlatform()
 
@@ -196,10 +198,9 @@ task integrationTest(type: Test) {
     systemProperty("integration-test.distribution.file.path", distTar.archiveFile.get().asFile.path)
 }
 
-test {
-    useJUnitPlatform {
-        includeEngines 'junit-jupiter'
-    }
+tasks.javadoc {
+    // disable missing javadoc lint and show only warning and error messages
+    options.addStringOption('Xdoclint:all,-missing', '-quiet')
 }
 
 processResources {
@@ -216,7 +217,7 @@ jar {
     }
 }
 
-task connectorConfigDoc {
+tasks.register('connectorConfigDoc') {
     description = "Generates the connector's configuration documentation."
     group = "documentation"
     dependsOn "classes"
@@ -248,7 +249,7 @@ spotless {
 }
 
 spotbugs {
-    toolVersion = "4.4.2"
+    toolVersion = "4.7.3"
     excludeFilter = file("${project.rootDir}/config/spotbugs-exclude.xml")
 }
 spotbugsMain {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionSha256Sum=cd5c2958a107ee7f0722004a12d0f8559b4564c34daad7df06cffd4d12a426d0
+distributionSha256Sum=5625a0ae20fe000d9225d000b36909c7a0e0e8dda61c19b12da769add847c975

--- a/src/integration-test/java/io/aiven/kafka/connect/http/SchemaRegistryContainer.java
+++ b/src/integration-test/java/io/aiven/kafka/connect/http/SchemaRegistryContainer.java
@@ -42,7 +42,7 @@ final class SchemaRegistryContainer extends GenericContainer<SchemaRegistryConta
     }
 
     public String getSchemaRegistryUrl() {
-        return String.format("http://%s:%s", getContainerIpAddress(), getMappedPort(SCHEMA_REGISTRY_PORT));
+        return String.format("http://%s:%s", getHost(), getMappedPort(SCHEMA_REGISTRY_PORT));
     }
 
 }


### PR DESCRIPTION
Changes:
- Bump gradle to 8.1.1
- Remove deprecated code
- Bump jetty dependency
- Bump tooling
- Remove deprecated calls on integrationTest