### PR TITLE
add support to handle records with null value

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=0.7.0-SNAPSHOT
+version=0.6.1

--- a/src/main/java/io/aiven/kafka/connect/http/config/BehaviorOnNullValue.java
+++ b/src/main/java/io/aiven/kafka/connect/http/config/BehaviorOnNullValue.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2019 Aiven Oy and http-connector-for-apache-kafka project contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.connect.http.config;
+
+public enum BehaviorOnNullValue {
+  FAIL, IGNORE, LOG;
+}

--- a/src/main/java/io/aiven/kafka/connect/http/config/HttpSinkConfig.java
+++ b/src/main/java/io/aiven/kafka/connect/http/config/HttpSinkConfig.java
@@ -74,6 +74,9 @@ public class HttpSinkConfig extends AbstractConfig {
 
     private static final String ERRORS_GROUP = "Errors Handling";
     private static final String ERRORS_TOLERANCE = "errors.tolerance";
+    private static final String BEHAVIOR_ON_NULL_VALUES = "behavior.on.null.values";
+    private static final BehaviorOnNullValue BEHAVIOR_ON_NULL_VALUES_DEFAULT = BehaviorOnNullValue.FAIL;
+
 
     public static ConfigDef configDef() {
         final ConfigDef configDef = new ConfigDef();
@@ -480,8 +483,20 @@ public class HttpSinkConfig extends AbstractConfig {
             ERRORS_GROUP,
             groupCounter++,
             ConfigDef.Width.SHORT,
-            HTTP_TIMEOUT_CONFIG
+            ERRORS_TOLERANCE
 
+        );
+        configDef.define(
+            BEHAVIOR_ON_NULL_VALUES,
+            ConfigDef.Type.STRING,
+            null,
+            ConfigDef.Importance.LOW,
+            "How to handle records with null value (that is, Kafka tombstone records)."
+               + " Valid Values: one of [fail, log, ignore]. Default is ignore",
+            ERRORS_GROUP,
+            groupCounter,
+            ConfigDef.Width.SHORT,
+            BEHAVIOR_ON_NULL_VALUES
         );
     }
 
@@ -582,6 +597,11 @@ public class HttpSinkConfig extends AbstractConfig {
     // currently just getting this for a configuration check
     private final String errorsTolerance() {
         return getString(ERRORS_TOLERANCE) != null ? getString(ERRORS_TOLERANCE) : "";
+    }
+
+    public BehaviorOnNullValue behaviorOnNullValues() {
+        return getString(BEHAVIOR_ON_NULL_VALUES) != null
+                ? BehaviorOnNullValue.valueOf(getString(BEHAVIOR_ON_NULL_VALUES)) : BEHAVIOR_ON_NULL_VALUES_DEFAULT;
     }
 
     // White space is significant for our batch delimiters but ConfigKey trims it out

--- a/src/main/java/io/aiven/kafka/connect/http/config/HttpSinkConfig.java
+++ b/src/main/java/io/aiven/kafka/connect/http/config/HttpSinkConfig.java
@@ -601,7 +601,7 @@ public class HttpSinkConfig extends AbstractConfig {
 
     public BehaviorOnNullValue behaviorOnNullValues() {
         return getString(BEHAVIOR_ON_NULL_VALUES) != null
-                ? BehaviorOnNullValue.valueOf(getString(BEHAVIOR_ON_NULL_VALUES)) : BEHAVIOR_ON_NULL_VALUES_DEFAULT;
+                ? BehaviorOnNullValue.valueOf(getString(BEHAVIOR_ON_NULL_VALUES).toUpperCase()) : BEHAVIOR_ON_NULL_VALUES_DEFAULT;
     }
 
     // White space is significant for our batch delimiters but ConfigKey trims it out


### PR DESCRIPTION
tombstone records currently cause the sink-task to stop, as an exception is thrown. Added a new config property "behavior.on.null.values" to control this behavior in a more granular fashion. The following enum values are allowed:
- ignore (default)
- fail
- log

 Also added details (partition,offset) about which record is failing on the given topic.