### PR TITLE
Replace key in dynamic endpoint

### DIFF
--- a/src/main/java/io/aiven/kafka/connect/http/recordsender/SingleRecordSender.java
+++ b/src/main/java/io/aiven/kafka/connect/http/recordsender/SingleRecordSender.java
@@ -32,13 +32,13 @@ final class SingleRecordSender extends RecordSender {
     public void send(final Collection<SinkRecord> records) {
         for (final SinkRecord record : records) {
             final String body = recordValueConverter.convert(record);
-            httpSender.send(body);
+            httpSender.send(body, record.key().toString());
         }
     }
 
     @Override
     public void send(final SinkRecord record) {
         final String body = recordValueConverter.convert(record);
-        httpSender.send(body);
+        httpSender.send(body, record.key().toString());
     }
 }

--- a/src/main/java/io/aiven/kafka/connect/http/sender/HttpSender.java
+++ b/src/main/java/io/aiven/kafka/connect/http/sender/HttpSender.java
@@ -20,4 +20,6 @@ import java.net.http.HttpResponse;
 
 public interface HttpSender {
     HttpResponse<String> send(final String body);
+
+    HttpResponse<String> send(final String body, String key);
 }


### PR DESCRIPTION
Added functionality to replace '{key}' with registry key to single records.

For example, url: https://example.com/{key}

Record with Key 11, new url: https://example.com/11