### PR TITLE
Add support for LinkedHashMap in record value

### DIFF
--- a/src/main/java/io/aiven/kafka/connect/http/converter/RecordValueConverter.java
+++ b/src/main/java/io/aiven/kafka/connect/http/converter/RecordValueConverter.java
@@ -17,6 +17,7 @@
 package io.aiven.kafka.connect.http.converter;
 
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 import org.apache.kafka.connect.data.Struct;
@@ -30,6 +31,7 @@ public class RecordValueConverter {
     private final Map<Class<?>, Converter> converters = Map.of(
             String.class, record -> (String) record.value(),
             HashMap.class, jsonRecordValueConverter,
+            LinkedHashMap.class, jsonRecordValueConverter,
             Struct.class, jsonRecordValueConverter
     );
 
@@ -40,7 +42,7 @@ public class RecordValueConverter {
     public String convert(final SinkRecord record) {
         if (!converters.containsKey(record.value().getClass())) {
             throw new DataException(
-                    "Record value must be String, Schema Struct or HashMap," 
+                    "Record value must be String, Schema Struct, LinkedHashMap or HashMap,"
                     + " but " + record.value().getClass() + " is given");
         }
         return converters.get(record.value().getClass()).convert(record);

--- a/src/test/java/io/aiven/kafka/connect/http/converter/RecordValueConverterTest.java
+++ b/src/test/java/io/aiven/kafka/connect/http/converter/RecordValueConverterTest.java
@@ -17,6 +17,7 @@
 package io.aiven.kafka.connect.http.converter;
 
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 import org.apache.kafka.connect.data.Field;
@@ -72,6 +73,21 @@ class RecordValueConverterTest {
         final var recordSchema = SchemaBuilder.map(Schema.STRING_SCHEMA, Schema.STRING_SCHEMA);
 
         final Map<String, String> value = new HashMap<>();
+        value.put("key", "value");
+
+        final var sinkRecord = new SinkRecord(
+                "some-topic", 0,
+                SchemaBuilder.string(),
+                "some-key", recordSchema, value, 1L);
+
+        assertThat(recordValueConverter.convert(sinkRecord)).isEqualTo("{\"key\":\"value\"}");
+    }
+
+    @Test
+    void convertLinkedHashMapRecord() {
+        final var recordSchema = SchemaBuilder.map(Schema.STRING_SCHEMA, Schema.STRING_SCHEMA);
+
+        final Map<String, String> value = new LinkedHashMap<>();
         value.put("key", "value");
 
         final var sinkRecord = new SinkRecord(


### PR DESCRIPTION
## Description

This pull request addresses an issue where the HTTP Connector for Apache Kafka does not support `LinkedHashMap` as the record value, leading to errors when used in conjunction with Single Message Transforms (SMTs) that return `LinkedHashMap`. The specific error message is: "Record value must be String, Schema Struct, or HashMap, but LinkedHashMap is given." 
This issue has specifically been encountered with certain SMTs from Confluent, such as `io.confluent.connect.transforms.Filter`, which can utilize LinkedHashMap in ways that the HTTP Connector previously could not handle.
## Changes Made

- Modified the relevant code to support `LinkedHashMap` as a valid record value.

## Testing

- Added test cases to ensure that the HTTP Connector functions correctly with record values of type `LinkedHashMap`.
- Ran existing tests to ensure backward compatibility.

## How to Verify

1. Build and test the modified connector.
2. Ensure that the connector now accepts and handles `LinkedHashMap` as the record value without generating errors.


## Checklist

- [ x ] Code follows the project's coding conventions.
- [x] Tests have been added to cover the changes.
- [x] Documentation has been updated to reflect the changes.
- [ x ] All existing tests pass.
