### PR TITLE
chore(doc): Correct the Kafka Connect REST API path in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ An example of configuration (file `connect-http-sink.json`):
 Then deploy the connector configuration against the Kafka Connect REST API with the following command:
 
 ```shell
-curl -d @config/connect-http-sink.json -H "Content-Type: application/json" -X POST http://localhost:8083/connector
+curl -d @config/connect-http-sink.json -H "Content-Type: application/json" -X POST http://localhost:8083/connectors
 ```
 
 See the [configuration options](docs/sink-connector-config-options.rst) for details.


### PR DESCRIPTION
issue: https://github.com/Aiven-Open/http-connector-for-apache-kafka/issues/238

The Kafka Connect REST API path on README is incorrect. This PR correct the path on readme.