### PR TITLE
feat: Configurable http codes to new access token

### DIFF
--- a/src/main/java/io/aiven/kafka/connect/http/sender/OAuth2HttpSender.java
+++ b/src/main/java/io/aiven/kafka/connect/http/sender/OAuth2HttpSender.java
@@ -48,10 +48,10 @@ class OAuth2HttpSender extends AbstractHttpSender implements HttpSender {
     protected HttpResponse<String> sendWithRetries(
         final Builder requestBuilder, final HttpResponseHandler originHttpResponseHandler, final int retries
     ) {
-        // This handler allows to request a new access token if a 401 occurs, meaning the session might be expired
+        // This handler allows to request a new access token if a an expected error occurs, meaning the session might be expired
         final HttpResponseHandler handler = (response, remainingRetries) -> {
-            // If the response has a 401 error and we have retries left, we attempt to renew the session
-            if (response.statusCode() == 401 && remainingRetries > 0) {
+            // If the response has one of the configured error codes and we have retries left, we attempt to renew the session
+            if (config.oauth2RenewTokenOnStatusCodes().contains(response.statusCode()) && remainingRetries > 0) {
                 // Update the request builder with the new access token
                 ((OAuth2AuthHttpRequestBuilder) this.httpRequestBuilder).renewAccessToken(requestBuilder);
                 // Retry the call and decrease the retries counter to avoid looping on token renewal


### PR DESCRIPTION
This PR fixes #289 by making the http error code which can trigger a token refresh configurable. The default value is 401 to avoid breaking changes.

Feedback is very welcome.
